### PR TITLE
Fix typo in README command to install Sketch plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Once this command has successfully run, the following files will be generated in
 These need to be imported into Sketch via html-sketchapp's corresponding Sketch plugin. To ease the install process, you can run the following command.
 
 ```bash
-$ html-sketchapp install
+$ html-sketchapp-install
 ```
 
 Then, open a new Sketch document and, from the menu, select `Plugins > From *Almost* Sketch to Sketch`. In the file picker, select both `document.asketch.json` and `page.asketch.json`, and click `Choose`.


### PR DESCRIPTION
Fixed a tiny typo in the README where the bash command to auto-install the Sketch plugin was incorrectly shown without the hyphen.